### PR TITLE
move from create_trajectory() to trajectory() in tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,5 +27,6 @@ Suggests:
     testthat,
     RcppDE,
     GenSA
+RoxygenNote: 5.0.1
 VignetteBuilder: knitr
 RoxygenNote: 7.1.2

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,7 +1,7 @@
 library(testthat)
 library(simmer.optim)
 
-if (-1 == utils::compareVersion("3.5.1", as.character(utils::packageVersion("simmer"))))
+if (-1 < utils::compareVersion("3.5.1", as.character(utils::packageVersion("simmer"))))
   trajectory <- create_trajectory
 
 test_check("simmer.optim")

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -5,5 +5,3 @@ if (-1 < utils::compareVersion("3.5.1", as.character(utils::packageVersion("simm
   trajectory <- create_trajectory
 
 test_check("simmer.optim")
-
-detach("package:simmer", unload = TRUE)

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,4 +1,9 @@
 library(testthat)
 library(simmer.optim)
 
+if (-1 == utils::compareVersion("3.5.1", as.character(utils::packageVersion("simmer"))))
+  trajectory <- create_trajectory
+
 test_check("simmer.optim")
+
+detach("package:simmer", unload = TRUE)


### PR DESCRIPTION
`create_trajectory()` will be deprecated and eventually removed from upcoming versions of `simmer` in favor of the more concise `trajectory()`.

Vignettes still use `create_trajectory()` while `simmer` 3.5.1 is on CRAN.